### PR TITLE
Fix logic for detecting _libc_fpstate API

### DIFF
--- a/src/lib/Iex/IexMathFpu.cpp
+++ b/src/lib/Iex/IexMathFpu.cpp
@@ -243,14 +243,14 @@ restoreControlRegs (const ucontext_t& ucon, bool clearExceptions)
 inline void
 restoreControlRegs (const ucontext_t& ucon, bool clearExceptions)
 {
-#        if defined(__GLIBC__) || defined(__i386__)
+#        if defined(__GLIBC__) && defined(__i386__)
     setCw ((ucon.uc_mcontext.fpregs->cw & cwRestoreMask) | cwRestoreVal);
 #        else
     setCw ((ucon.uc_mcontext.fpregs->cwd & cwRestoreMask) | cwRestoreVal);
 #        endif
 
     _fpstate* kfp = reinterpret_cast<_fpstate*> (ucon.uc_mcontext.fpregs);
-#        if defined(__GLIBC__) || defined(__i386__)
+#        if defined(__GLIBC__) && defined(__i386__)
     setMxcsr (kfp->magic == 0 ? kfp->mxcsr : 0, clearExceptions);
 #        else
     setMxcsr (kfp->mxcsr, clearExceptions);


### PR DESCRIPTION
This fixes use of the incorrect libc API on x86 64-bit Linux, which was causing OpenEXR compilation to fail on the latest 64-bit Ubuntu.

See https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/x86/sys/ucontext.h which defines two different `_libc_fpstate` structs inside an `#ifdef __x86_64__`

I will note that I haven't attempted to test this change on all platforms, but it fixed a broken compile for me and I believe it makes more sense this way. Perhaps @nh2 who originally added these lines of code I'm changing (in https://github.com/AcademySoftwareFoundation/openexr/commit/c7af102e6bce6638add2f38576ffe9c6741ba768) could comment.